### PR TITLE
use createOrUpdate when creating marketo leads

### DIFF
--- a/marketo/marketo.go
+++ b/marketo/marketo.go
@@ -4,14 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	clinic "github.com/tidepool-org/clinic/client"
 	"log"
 	"net/url"
 	"strings"
 
-	"github.com/tidepool-org/go-common/clients/shoreline"
-
 	"github.com/SpeakData/minimarketo"
+
+	clinic "github.com/tidepool-org/clinic/client"
+	"github.com/tidepool-org/go-common/clients/shoreline"
 )
 
 const path = "/rest/v1/leads.json?"
@@ -240,12 +240,15 @@ func (m *Connector) UpsertListMember(userId, listEmail string, input Input) erro
 	if !exists {
 		input.ID = 0
 		data = CreateData{
-			"createOnly",
+			"createOrUpdate",
 			"email",
 			[]Input{input},
 		}
 	}
 	dataInBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshaling marketo CreateData: %w", err)
+	}
 	response, err := m.client.Post(path, dataInBytes)
 	if err != nil {
 		m.logger.Println(err)
@@ -256,7 +259,7 @@ func (m *Connector) UpsertListMember(userId, listEmail string, input Input) erro
 		return fmt.Errorf("marketo: issue with request %v", response.Errors)
 	}
 	var createResults []minimarketo.RecordResult
-	if err = json.Unmarshal(response.Result, &createResults); err != nil {
+	if err := json.Unmarshal(response.Result, &createResults); err != nil {
 		m.logger.Println(err)
 		return fmt.Errorf("marketo: could not get a response %v", err)
 	}

--- a/marketo/marketo_test.go
+++ b/marketo/marketo_test.go
@@ -3,7 +3,6 @@ package marketo_test
 import (
 	"encoding/json"
 	"fmt"
-	clinic "github.com/tidepool-org/clinic/client"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -13,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	clinic "github.com/tidepool-org/clinic/client"
 	"github.com/tidepool-org/go-common/clients/shoreline"
 	"github.com/tidepool-org/marketo-service/marketo"
 )
@@ -396,7 +396,7 @@ const (
 		"success":true
 	}`
 	createLeadRequest = `{
-		"action":"createOnly",
+		"action":"createOrUpdate",
 		"lookupField":"email",
 		"input": [{"email": "%s", "firstName": "%s", "lastName": "%s", "userType": "%s"}]
 	}`
@@ -598,8 +598,8 @@ func Test_CreateListMember(t *testing.T) {
 			if len(requestBody.Input) != 1 {
 				t.Errorf("Expected one lead, got %d", len(requestBody.Input))
 			}
-			if requestBody.Action != "createOnly" {
-				t.Errorf("Expected 'createOnly', got %s", requestBody.Action)
+			if requestBody.Action != "createOrUpdate" {
+				t.Errorf("Expected 'createOrUpdate', got %s", requestBody.Action)
 			}
 			if requestBody.LookupField != "email" {
 				t.Errorf("Expected 'email', got %s", requestBody.LookupField)


### PR DESCRIPTION
Many duplicate leads have been created. Logs show that we might be calling marketo up to 5x (or more?) for a newly created user. By switching from createOnly to createOrUpdate, I hope to allow marketo to deduplicate on the email address, which will hopefully minimize the number of duplicates created.

The API docs are not clear about the circumstances under which duplicates are created. They indicate only that when multiple requests with the same "key" arrive in rapid succession, duplicates can happen. They don't define the "key" however. I think it's logical to assume that it's the "LookupField" parameter, which is ignored when using createOnly, but should be valid when using createOrUpdate, hence the change.

BACK-2999